### PR TITLE
Apollo client - Query

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "@apollo/react-hooks": "^3.1.3",
+    "apollo-boost": "^0.4.7",
+    "graphql": "^14.5.8",
     "moment": "2.24.0",
     "node-sass": "^4.12.0",
     "nouislider": "14.0.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "moment": "2.24.0",
     "node-sass": "^4.12.0",
     "nouislider": "14.0.2",
+    "prop-types": "^15.7.2",
     "react": "16.8.6",
     "react-bootstrap-switch": "15.5.3",
     "react-countdown-now": "^2.1.2",

--- a/src/components/api.js
+++ b/src/components/api.js
@@ -1,0 +1,2 @@
+export { default as ApiQuery } from './api/ApiQuery';
+export { default as Client } from './api/Client';

--- a/src/components/api/ApiQuery.js
+++ b/src/components/api/ApiQuery.js
@@ -1,0 +1,56 @@
+/* eslint-disable react/jsx-props-no-spreading */
+/**
+ * NOTE this is a HOC
+ * > don't use inside a render() method since HOC creates a copy of the wrapped component
+ * > Usage e.g.:
+ * 
+ * function Component({ apiData }) {
+ *  return apiData.forEach(({ id, title }) => (
+ *    <>
+ *      <span>{id}</span>
+ *      <span>{title}</span>
+ *    </>
+ *  );
+ * }
+ * export ApiQuery(Component, `
+ *  {
+ *    todo {
+ *      id
+ *      title
+ *    }
+ *  }
+ * `)
+ * 
+ * Your Component will be decorated with the new property 'apiData'
+ * 
+ * > mind static methods of wrapped components
+ * > https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over
+ * > the suggested solution is to export the static method separately from the component itself.
+ * > mind refs problem
+ * > https://reactjs.org/docs/higher-order-components.html#refs-arent-passed-through
+ */
+import React from 'react';
+import { useQuery } from '@apollo/react-hooks';
+import { gql } from 'apollo-boost';
+import Loading from './Loading';
+import Error from './Error';
+
+function ApiQuery(WrappedComponent, query) {
+  const { loading, error, data } = useQuery(gql`${query}`);
+
+  if (loading) return <Loading />;
+  if (error) return <Error />;
+  
+  const Wrapper = (props) => (
+    <WrappedComponent apiData={data} {...props} />
+  );
+
+  Wrapper.displayName = `ApiQuery(${
+    WrappedComponent.displayName ||
+    WrappedComponent.name
+  })`;
+  
+  return Wrapper;
+}
+
+export default ApiQuery;

--- a/src/components/api/ApiQuery.js
+++ b/src/components/api/ApiQuery.js
@@ -56,15 +56,19 @@ function ApiQuery(WrappedComponent, query, queryHookOptions) {
     });
     if (loading) return <Loading />;
     if (error) return <Error error={error} />;    
+    const { forwardedRef, ...rest } = props;
     return (
       <WrappedComponent
         apiData={data}
         refetch={refetch}
-        {...props} />
+        ref={forwardedRef}
+        {...rest} />
     );
   }
   Wrapper.displayName = `Component-${displayName}`;  
-  return Wrapper;
+  return React.forwardRef((props, ref) => {
+    return <Wrapper {...props} forwardedRef={ref} />;
+  });
 }
 
 export default ApiQuery;

--- a/src/components/api/ApiQuery.js
+++ b/src/components/api/ApiQuery.js
@@ -38,21 +38,29 @@ import Error from './Error';
 // NOTE => could be used <ApolloProvider> instead
 import Client from './Client';
 
-function ApiQuery(WrappedComponent, query, ...queryHookOptions) {
+function ApiQuery(WrappedComponent, query, queryHookOptions) {
   const displayName = `ApiQuery(${
     WrappedComponent.displayName ||
     WrappedComponent.name
   })`;
   const Wrapper = (props) => {
-    const { loading, error, data } = useQuery(gql`${query}`, {
+    const {
+      loading,
+      error,
+      data,
+      refetch,
+    } = useQuery(gql`${query}`, {
       client: Client,
       displayName,
       ...queryHookOptions,
     });
     if (loading) return <Loading />;
-    if (error) return <Error />;    
+    if (error) return <Error error={error} />;    
     return (
-      <WrappedComponent apiData={data} {...props} />
+      <WrappedComponent
+        apiData={data}
+        refetch={refetch}
+        {...props} />
     );
   }
   Wrapper.displayName = `Component-${displayName}`;  

--- a/src/components/api/ApiQuery.js
+++ b/src/components/api/ApiQuery.js
@@ -5,7 +5,7 @@
  * > Usage e.g.:
  * 
  * function Component({ apiData }) {
- *  return apiData.forEach(({ id, title }) => (
+ *  return apiData.todo.map(({ id, title }) => (
  *    <>
  *      <span>{id}</span>
  *      <span>{title}</span>
@@ -19,7 +19,7 @@
  *      title
  *    }
  *  }
- * `)
+ * `);
  * 
  * Your Component will be decorated with the new property 'apiData'
  * 
@@ -35,21 +35,27 @@ import { gql } from 'apollo-boost';
 import Loading from './Loading';
 import Error from './Error';
 
-function ApiQuery(WrappedComponent, query) {
-  const { loading, error, data } = useQuery(gql`${query}`);
+// NOTE => could be used <ApolloProvider> instead
+import Client from './Client';
 
-  if (loading) return <Loading />;
-  if (error) return <Error />;
-  
-  const Wrapper = (props) => (
-    <WrappedComponent apiData={data} {...props} />
-  );
-
-  Wrapper.displayName = `ApiQuery(${
+function ApiQuery(WrappedComponent, query, ...queryHookOptions) {
+  const displayName = `ApiQuery(${
     WrappedComponent.displayName ||
     WrappedComponent.name
   })`;
-  
+  const Wrapper = (props) => {
+    const { loading, error, data } = useQuery(gql`${query}`, {
+      client: Client,
+      displayName,
+      ...queryHookOptions,
+    });
+    if (loading) return <Loading />;
+    if (error) return <Error />;    
+    return (
+      <WrappedComponent apiData={data} {...props} />
+    );
+  }
+  Wrapper.displayName = `Component-${displayName}`;  
   return Wrapper;
 }
 

--- a/src/components/api/Client.js
+++ b/src/components/api/Client.js
@@ -1,0 +1,7 @@
+import ApolloClient from 'apollo-boost';
+
+export default new ApolloClient({
+  // TODO backend api endpoint => retrieve from
+  // (e.g.) env variables or global configs
+  uri: 'https://48p1r2roz4.sse.codesandbox.io',
+});

--- a/src/components/api/Client.js
+++ b/src/components/api/Client.js
@@ -3,5 +3,5 @@ import ApolloClient from 'apollo-boost';
 export default new ApolloClient({
   // TODO backend api endpoint => retrieve from
   // (e.g.) env variables or global configs
-  uri: 'https://48p1r2roz4.sse.codesandbox.io',
+  uri: 'https://dpq3s.sse.codesandbox.io/',
 });

--- a/src/components/api/Error.js
+++ b/src/components/api/Error.js
@@ -17,7 +17,7 @@ function Error({ error }) {
       <h3>Error</h3>
       <p>{message}</p>
       <p>{extraInfo}</p>
-      {networkError.result.errors.map((x) => (
+      {networkError?.result?.errors?.map((x) => (
         <p key={x}>{x.message}</p>
       ))}
     </Container>

--- a/src/components/api/Error.js
+++ b/src/components/api/Error.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Container } from 'reactstrap';
+
+function Error() {
+  return (
+    <Container>
+      <span>Error...</span>
+    </Container>
+  );
+}
+
+export default Error;

--- a/src/components/api/Error.js
+++ b/src/components/api/Error.js
@@ -1,12 +1,45 @@
+/* eslint-disable no-console */
 import React from 'react';
 import { Container } from 'reactstrap';
+import PropTypes from 'prop-types';
 
-function Error() {
+function Error({ error }) {
+  const {
+    graphQLErrors,
+    networkError,
+    message,
+    extraInfo,
+  } = error;
+  console.error('GraphQL', graphQLErrors);
+  console.error('Network', networkError);
   return (
     <Container>
-      <span>Error...</span>
+      <h3>Error</h3>
+      <p>{message}</p>
+      <p>{extraInfo}</p>
+      {networkError.result.errors.map((x) => (
+        <p key={x}>{x.message}</p>
+      ))}
     </Container>
   );
 }
+
+Error.propTypes = {
+  error: PropTypes.exact({
+    message: PropTypes.string,
+    extraInfo: PropTypes.string,
+    graphQLErrors: PropTypes.array,
+    networkError: PropTypes.object,
+  }),  
+};
+
+Error.defaultProps = {
+  error: {
+    message: '',
+    extraInfo: '',
+    graphQLErrors: [],
+    networkError: {},
+  },
+};
 
 export default Error;

--- a/src/components/api/Loading.js
+++ b/src/components/api/Loading.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Container } from 'reactstrap';
+
+function Loading() {
+  return (
+    <Container>
+      <span>...</span>
+    </Container>
+  );
+}
+
+export default Loading;

--- a/src/index.js
+++ b/src/index.js
@@ -29,11 +29,13 @@ import NucleoIcons from "views/NucleoIcons.js";
 import LoginPage from "views/examples/LoginPage.js";
 import ProfilePage from "views/examples/ProfilePage.js";
 import RegisterPage from "views/index-sections/SignUp";
+import PageFetchingData from 'views/examples/PageFetchingData';
 
 ReactDOM.render(
   <BrowserRouter>
     <Switch>
       <Switch>
+        <Route path="/eg" render={props => <PageFetchingData {...props} />} />
         <Route path="/index" render={props => <Index {...props} />} />
         <Route
           path="/nucleo-icons"

--- a/src/views/examples/PageFetchingData.js
+++ b/src/views/examples/PageFetchingData.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { ApiQuery } from 'components/api';
+
+function PageFetchingData({ apiData }) {
+  return apiData.rates.map(({ currency, rate }) => (
+    <div key={currency}>
+      <p>
+        {currency}: {rate}
+      </p>
+    </div>
+  ));
+}
+
+export default ApiQuery(PageFetchingData, `
+  {
+    rates(currency: "USD") {
+      currency
+      rate
+    }
+  }
+`);

--- a/src/views/examples/PageFetchingData.js
+++ b/src/views/examples/PageFetchingData.js
@@ -1,21 +1,42 @@
 import React from 'react';
 import { ApiQuery } from 'components/api';
 
-function PageFetchingData({ apiData }) {
-  return apiData.rates.map(({ currency, rate }) => (
-    <div key={currency}>
-      <p>
-        {currency}: {rate}
-      </p>
-    </div>
-  ));
+let currency = 'USD';
+
+function PageFetchingData({ apiData, refetch }) {
+  // NOTE this is quite a bad example of state managements
+  // since we are in stateless component. For the sake of
+  // showing how to handle variables in queries.
+  const updateCurrency = ({ target: { value }}) => {
+    currency = value;
+  }
+  const fetchRates = (e) => {
+    e.preventDefault();
+    refetch({ currency })
+  }
+  return (
+    <>
+      <form onSubmit={fetchRates}>
+        <input type="text" defaultValue={currency} onChange={updateCurrency} />
+      </form>
+      {apiData.rates && apiData.rates.map(({ currency, rate }) => (
+        <div key={currency}>
+          <p>
+            {currency}: {rate}
+          </p>
+        </div>
+      ))}
+    </>
+  )
 }
 
 export default ApiQuery(PageFetchingData, `
-  {
-    rates(currency: "USD") {
+  query ($currency: String!) {
+    rates(currency: $currency) {
       currency
       rate
     }
   }
-`);
+`, {
+  variables: { currency }
+});

--- a/src/views/examples/PageFetchingData.js
+++ b/src/views/examples/PageFetchingData.js
@@ -19,7 +19,7 @@ function PageFetchingData({ apiData, refetch }) {
       <form onSubmit={fetchRates}>
         <input type="text" defaultValue={currency} onChange={updateCurrency} />
       </form>
-      {apiData.rates && apiData.rates.map(({ currency, rate }) => (
+      {apiData.rates?.map(({ currency, rate }) => (
         <div key={currency}>
           <p>
             {currency}: {rate}


### PR DESCRIPTION
API communication through Apollo Client
- [https://www.apollographql.com/docs/react/](https://www.apollographql.com/docs/react/)
- Keeping API related code and Apollo Cliente wrapped away from the application code (components/api)
- Providing an interface as [HOC](https://reactjs.org/docs/higher-order-components.html), minimum example and notes on components/api/ApiQuery.js
- Using a ready example GraphQL endpoint on the sandbox:
[![Edit Apollo Server + Coinbase API](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/apollo-server-coinbase-api-dpq3s?fontsize=14&hidenavigation=1&theme=dark)


🚧 Note: client, graphQL 'queries' have been implemented, still missing 'mutations' that will follow the same patterns of 'query'.